### PR TITLE
Added bundleResourcePath variable to FBSnapshotTestController which c…

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -39,6 +39,16 @@
     _snapshotController.recordMode = recordMode;
 }
 
+- (NSBundle *)bundleResourcePath
+{
+    return _snapshotController.bundleResourcePath;
+}
+
+- (void)setBundleResourcePath:(NSBundle *)bundleResourcePath
+{
+    _snapshotController.bundleResourcePath = bundleResourcePath;
+}
+
 - (FBSnapshotTestCaseFileNameIncludeOption)fileNameOptions
 {
     return _snapshotController.fileNameOptions;
@@ -242,7 +252,13 @@
     if (dir && dir.length > 0) {
         return dir;
     }
-    return [[NSBundle bundleForClass:self.class].resourcePath stringByAppendingPathComponent:@"ReferenceImages"];
+    NSString* _Nonnull bundleResourcePath;
+    if (_snapshotController.bundleResourcePath == nil) {
+        bundleResourcePath = [NSBundle bundleForClass:self.class].resourcePath;
+    } else {
+        bundleResourcePath = _snapshotController.bundleResourcePath;
+    }
+    return [bundleResourcePath stringByAppendingPathComponent:@"ReferenceImages"];
 }
 
 - (NSString *)getImageDiffDirectoryWithDefault:(NSString *)dir

--- a/FBSnapshotTestCase/Public/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/Public/FBSnapshotTestCase.h
@@ -21,7 +21,8 @@
     c-string with the path. This only works for Objective-C tests.
  2. Set an environment variable named FB_REFERENCE_IMAGE_DIR with the path. This
     takes precedence over the preprocessor macro to allow for run-time override.
- 3. Keep everything unset, which will cause the reference images to be looked up
+ 3. Set `FBSnapshotTestCase.bundleResourcePath` as the root folder where reference images are stored.
+ 4. Keep everything unset, which will cause the reference images to be looked up
     inside the bundle holding the current test, in the
     Resources/ReferenceImages_* directories.
  */
@@ -133,6 +134,13 @@ NS_ASSUME_NONNULL_BEGIN
  When YES, the test macros will save reference images, rather than performing an actual test.
  */
 @property (readwrite, nonatomic, assign) BOOL recordMode;
+
+
+/**
+ The bundleResourcePath can be manually set to the root folder where reference images are stored.
+ If the bundle is not set via FB_REFERENCE_IMAGE_DIR (Steps 1, 2 stated above) then it checks if bundleResourcePath is set. This is useful for testing with SPM
+ */
+@property (readwrite, nonatomic, copy, nullable) NSString *bundleResourcePath;
 
 /**
  When set, allows fine-grained control over what you want the file names to include.

--- a/FBSnapshotTestCase/Public/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/Public/FBSnapshotTestController.h
@@ -58,6 +58,11 @@ extern NSString *const FBDiffedImageKey;
 @property (readwrite, nonatomic, assign) BOOL recordMode;
 
 /**
+ The bundleResourcePath can be manually set to the root folder where reference images are stored.
+ */
+@property (readwrite, nonatomic, copy, nullable) NSString *bundleResourcePath;
+
+/**
  When set, allows fine-grained control over what you want the file names to include.
 
  Allows you to combine which device or simulator specific details you want in your snapshot file names.


### PR DESCRIPTION
Swift Package Manager (SPM) additional PR.

This PR adds one commit over bfernandesbfs SPM PR

This adds a new bundleResourcePath variable to FBSnapshotTestController which can be manually set as the root folder where reference images are stored, which is needed for SPM. After this change there are now 4 ways of setting reference image directories instead of 3:

    Set the preprocessor macro FB_REFERENCE_IMAGE_DIR to a double quoted c-string with the path. This only works for Objective-C tests.
    Set an environment variable named FB_REFERENCE_IMAGE_DIR with the path. This takes precedence over the preprocessor macro to allow for run-time override.
    (New way) Set FBSnapshotTestCase.bundleResourcePath as the root folder where reference images are stored.
    Keep everything unset, which will cause the reference images to be looked up inside the bundle holding the current test, in the Resources/ReferenceImages_* directories.
