### PR TITLE
Added referenceImagesPath variable to FBSnapshotTestController which …

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -39,14 +39,34 @@
     _snapshotController.recordMode = recordMode;
 }
 
-- (NSBundle *)bundleResourcePath
+- (nullable NSString *)bundleResourcePath
 {
     return _snapshotController.bundleResourcePath;
 }
 
-- (void)setBundleResourcePath:(NSBundle *)bundleResourcePath
+- (void)setBundleResourcePath:(nullable NSString *)bundleResourcePath
 {
     _snapshotController.bundleResourcePath = bundleResourcePath;
+}
+
+- (nullable NSString *)referenceImagesPath
+{
+    return _snapshotController.referenceImagesPath;
+}
+
+- (void)setReferenceImagesPath:(nullable NSString *)referenceImagesPath
+{
+    _snapshotController.referenceImagesPath = referenceImagesPath;
+}
+
+- (nullable NSString *)diffImagesPath
+{
+    return _snapshotController.diffImagesPath;
+}
+
+- (void)setDiffImagesPath:(nullable NSString *)diffImagesPath
+{
+    _snapshotController.diffImagesPath = diffImagesPath;
 }
 
 - (FBSnapshotTestCaseFileNameIncludeOption)fileNameOptions
@@ -252,13 +272,13 @@
     if (dir && dir.length > 0) {
         return dir;
     }
-    NSString* _Nonnull bundleResourcePath;
-    if (_snapshotController.bundleResourcePath == nil) {
-        bundleResourcePath = [NSBundle bundleForClass:self.class].resourcePath;
+    if (_snapshotController.bundleResourcePath != nil) {
+        return [_snapshotController.bundleResourcePath stringByAppendingPathComponent: @"ReferenceImages"];
+    } else if (_snapshotController.referenceImagesPath != nil) {
+        return _snapshotController.referenceImagesPath;
     } else {
-        bundleResourcePath = _snapshotController.bundleResourcePath;
+        return [[NSBundle bundleForClass: self.class].resourcePath stringByAppendingPathComponent: @"ReferenceImages"];
     }
-    return [bundleResourcePath stringByAppendingPathComponent:@"ReferenceImages"];
 }
 
 - (NSString *)getImageDiffDirectoryWithDefault:(NSString *)dir
@@ -269,6 +289,9 @@
     }
     if (dir && dir.length > 0) {
         return dir;
+    }
+    if (_snapshotController.diffImagesPath != nil) {
+        return _snapshotController.diffImagesPath;
     }
     return NSTemporaryDirectory();
 }

--- a/FBSnapshotTestCase/Public/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/Public/FBSnapshotTestCase.h
@@ -21,8 +21,9 @@
     c-string with the path. This only works for Objective-C tests.
  2. Set an environment variable named FB_REFERENCE_IMAGE_DIR with the path. This
     takes precedence over the preprocessor macro to allow for run-time override.
- 3. Set `FBSnapshotTestCase.bundleResourcePath` as the root folder where reference images are stored.
- 4. Keep everything unset, which will cause the reference images to be looked up
+ 3. Set `FBSnapshotTestCase.bundleResourcePath` as the bundle path where the reference image folder is stored.
+ 4. Set `FBSnapshotTestCase.referenceImagesPath` as the reference image folder.
+ 5. Keep everything unset, which will cause the reference images to be looked up
     inside the bundle holding the current test, in the
     Resources/ReferenceImages_* directories.
  */
@@ -37,7 +38,8 @@
  c-string with the path.
  2. Set an environment variable named IMAGE_DIFF_DIR with the path. This
  takes precedence over the preprocessor macro to allow for run-time override.
- 3. Keep everything unset, which will cause the failed image diff images to be saved
+ 3. Set `FBSnapshotTestCase.diffImagesPath` as the diff images folder.
+ 4. Keep everything unset, which will cause the failed image diff images to be saved
  inside a temporary directory.
  */
 #ifndef IMAGE_DIFF_DIR
@@ -135,12 +137,24 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (readwrite, nonatomic, assign) BOOL recordMode;
 
+/**
+The bundleResourcePath can be manually set to the bundle path where the reference image folder is stored.
+If the bundle is not set via FB_REFERENCE_IMAGE_DIR (Steps 1, 2 stated above) then it checks if bundleResourcePath is set. This is useful for testing in swift without schemes
+ */
+
+@property (readwrite, nonatomic, copy, nullable) NSString *bundleResourcePath;
 
 /**
- The bundleResourcePath can be manually set to the root folder where reference images are stored.
- If the bundle is not set via FB_REFERENCE_IMAGE_DIR (Steps 1, 2 stated above) then it checks if bundleResourcePath is set. This is useful for testing with SPM
+ The referenceImagesPath can be manually set as the reference image folder.
+ If the bundle is not set via FB_REFERENCE_IMAGE_DIR and bundleResourcePath (Steps 1, 2, 3 stated above) then it checks if referenceImagesPath is set. This is useful for testing in swift without schemes
  */
-@property (readwrite, nonatomic, copy, nullable) NSString *bundleResourcePath;
+@property (readwrite, nonatomic, copy, nullable) NSString *referenceImagesPath;
+
+/**
+ The diffImagesPath can be manually set as the folder where diff images are stored.
+ If the bundle is not set via IMAGE_DIFF_DIR (Steps 1, 2 stated above) then it checks if diffImagesPath is set. This is useful for testing in swift without schemes
+ */
+@property (readwrite, nonatomic, copy, nullable) NSString *diffImagesPath;
 
 /**
  When set, allows fine-grained control over what you want the file names to include.

--- a/FBSnapshotTestCase/Public/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/Public/FBSnapshotTestController.h
@@ -58,9 +58,19 @@ extern NSString *const FBDiffedImageKey;
 @property (readwrite, nonatomic, assign) BOOL recordMode;
 
 /**
- The bundleResourcePath can be manually set to the root folder where reference images are stored.
- */
+ The bundleResourcePath can be manually set to the bundle path where reference image folder is stored.
+*/
 @property (readwrite, nonatomic, copy, nullable) NSString *bundleResourcePath;
+
+/**
+ The referenceImagesPath can be manually set as the reference images folder.
+ */
+@property (readwrite, nonatomic, copy, nullable) NSString *referenceImagesPath;
+
+/**
+ The diffImagesPath can be manually set as the diff images folder.
+ */
+@property (readwrite, nonatomic, copy, nullable) NSString *diffImagesPath;
 
 /**
  When set, allows fine-grained control over what you want the file names to include.


### PR DESCRIPTION
…can be manually set as the folder where reference images are stored and added diffImagesPath variable to FBSnapshotTestController which can be manually set as the folder where diff images are stored. This all helps with SPM and carthage working together without needing schemes in swift.